### PR TITLE
Preserve the TypeError message when raising a CommitFailedError.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - 2.7
   - 3.4
   - 3.5
+  - 3.6
   - pypy
 script:
   - coverage run `which zope-testrunner` --test-path=src  --auto-color --auto-progress

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changes
 1.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- When the ``TransactionLoop`` raises a ``CommitFailedError`` from a
+  ``TypeError``, it preserves the original message.
 
 
 1.1.0 (2017-04-17)

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,9 @@ entry_points = {
 }
 
 TESTS_REQUIRE = [
-    'nose2[coverage_plugin]',
     'zope.testrunner',
     'nti.testing',
+    'fudge',
 ]
 
 def _read(fname):
@@ -38,6 +38,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Framework :: ZODB',

--- a/src/nti/transactions/transactions.py
+++ b/src/nti/transactions/transactions.py
@@ -7,7 +7,6 @@ This module imports the :mod:`dm.transaction.aborthook` module and
 directly provides the :func:`add_abort_hooks` function; you should
 call this if you need such functionality.
 
-.. $Id$
 """
 
 from __future__ import print_function, unicode_literals, absolute_import, division
@@ -278,7 +277,7 @@ def _do_commit(tx, description, long_commit_duration):
     except TypeError:
         # Translate this into something meaningful
         exc_info = sys.exc_info()
-        six.reraise(CommitFailedError, None, exc_info[2])
+        six.reraise(CommitFailedError, CommitFailedError(exc_info[1]), exc_info[2])
     except (AssertionError, ValueError):
         # We've seen this when we are recalled during retry handling. The higher level
         # is in the process of throwing a different exception and the transaction is
@@ -294,6 +293,8 @@ def _do_commit(tx, description, long_commit_duration):
             six.reraise(*exc_info)
 
         raise
+    finally:
+        del exc_info
 
 from perfmetrics import Metric
 


### PR DESCRIPTION
Fixes #13