### PR TITLE
Be more careful about not keeping tracebacks alive.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ Changes
 
 - Test support for Python 3.7; remove test support for Python 3.4.
 
+- ``TransactionLoop`` is more careful to not keep traceback objects
+  around, especially on Python 2.
+
 1.1.1 (2018-07-19)
 ------------------
 


### PR DESCRIPTION
Especially on Python 2. Every time the loop begins again for retry, we call sys.exc_clear() to avoid keeping the previous exception around while the handler runs again. The previous traceback could be consuming a lot of memory.