### PR TITLE
Use an explicit transaction manager. Fixes #20

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,22 +1,26 @@
 
-Changes
-========
+=========
+ Changes
+=========
 
-2.0.2 (unreleased)
-------------------
+3.0.0 (unreleased)
+==================
 
-- Nothing changed yet.
-
+- Make ``TransactionLoop`` place its transaction manager in explicit
+  mode. This can be faster and is easier to reason about, but forbids
+  the called handler from manually calling ``begin()``, ``abort()`` or
+  ``commit()``. See `issue 20
+  <https://github.com/NextThought/nti.transactions/issues/20>`_.
 
 2.0.1 (2019-09-03)
-------------------
+==================
 
 - Fix compatibility with perfmetrics 3.0: drop ``from __future__
   import unicode_literals``.
 
 
 2.0.0 (2018-07-20)
-------------------
+==================
 
 - Use the new public ``isRetryableError`` in transaction 2.2. The
   interface for this package is unchanged, but a major version bump of
@@ -29,7 +33,7 @@ Changes
   around, especially on Python 2.
 
 1.1.1 (2018-07-19)
-------------------
+==================
 
 - When the ``TransactionLoop`` raises a ``CommitFailedError`` from a
   ``TypeError``, it preserves the original message.
@@ -37,14 +41,14 @@ Changes
 - Test support for Python 3.6.
 
 1.1.0 (2017-04-17)
-------------------
+==================
 
 - Add a new ObjectDataManager that will attempt to execute after
   other ObjectDataManagers.
 
 
 1.0.0 (2016-07-28)
-------------------
+==================
 
 - Add support for Python 3.
 - Eliminate ZODB dependency. Instead of raising a

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         'setuptools',
         'dm.transaction.aborthook',
         'perfmetrics',
-        'transaction >= 2.2.1',
+        'transaction >= 2.4.0',
         'zope.exceptions',
         'zope.interface',
     ],

--- a/src/nti/transactions/interfaces.py
+++ b/src/nti/transactions/interfaces.py
@@ -26,3 +26,11 @@ class AbortFailedError(TransactionError):
     This is raised instead of raising very generic system exceptions
     such as ValueError and AttributeError.
     """
+
+class ForeignTransactionError(TransactionError):
+    """
+    Raised when a transaction manager has its transaction changed
+    while a controlling transaction loop believes it is in control.
+
+    This is a programming error.
+    """


### PR DESCRIPTION
And remove legacy freeing of transaction resources that hadn't been needed since transaction 1.6 or so. Fixes #18.