### PR TITLE
Add additional hooks for subclasses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,12 @@
   retried. Previously, an error there would probably be raised
   *anyway* and not retried, unless a subclass had made customizations.
 
+- Add ``setUp`` and ``tearDown`` methods to TransactionLoop to give
+  subclasses a place to hook into the inners of the transaction loop.
+  This is particularly helpful if they need to do something after the
+  transaction manager has been put in explicit mode. See `issue 22
+  <https://github.com/NextThought/nti.transactions/issues/22>`_.
+
 2.0.1 (2019-09-03)
 ==================
 

--- a/src/nti/transactions/interfaces.py
+++ b/src/nti/transactions/interfaces.py
@@ -27,10 +27,28 @@ class AbortFailedError(TransactionError):
     such as ValueError and AttributeError.
     """
 
-class ForeignTransactionError(TransactionError):
+class TransactionLifecycleError(TransactionError):
+    """
+    Raised when an application commits or aborts a transaction
+    while the transaction controller believes it is in control.
+
+    *Applications must not raise this exception.*
+
+    This may have happened many times; we cannot detect that.
+
+    This is a programming error.
+    """
+
+class ForeignTransactionError(TransactionLifecycleError):
     """
     Raised when a transaction manager has its transaction changed
     while a controlling transaction loop believes it is in control.
+
+    The handler first aborted or committed the transaction, and then
+    began a new one. Possibly many times.
+
+    A kind of `TransactionLifecycleError`. *Applications must not
+    raise this exception.*
 
     This is a programming error.
     """

--- a/src/nti/transactions/tests/test_transaction.py
+++ b/src/nti/transactions/tests/test_transaction.py
@@ -14,6 +14,7 @@ from hamcrest import calling
 from hamcrest import raises
 from hamcrest import contains
 from hamcrest import has_property
+from hamcrest import none
 
 import fudge
 
@@ -23,6 +24,7 @@ from nti.testing.matchers import is_false
 from ..interfaces import CommitFailedError
 from ..interfaces import AbortFailedError
 from ..interfaces import ForeignTransactionError
+from ..interfaces import TransactionLifecycleError
 
 from ..transactions import do
 from ..transactions import do_near_end
@@ -119,11 +121,22 @@ class TestLoop(unittest.TestCase):
 
         assert_that(calling(TransactionLoop(handler)), raises(AlreadyInTransaction))
 
+    def test_explicit_begin_after_commit(self):
+        # We change the current transaction out and then still manage to raise
+        # AlreadyInTransaction
+        def handler():
+            transaction.abort()
+            transaction.begin()
+            transaction.begin()
+
+        assert_that(calling(TransactionLoop(handler)), raises(AlreadyInTransaction))
+
+
     def test_explicit_end(self):
         def handler():
             transaction.abort()
 
-        assert_that(calling(TransactionLoop(handler)), raises(NoTransaction))
+        assert_that(calling(TransactionLoop(handler)), raises(TransactionLifecycleError))
 
     def test_explicit_foreign(self):
         def handler():
@@ -131,6 +144,18 @@ class TestLoop(unittest.TestCase):
             transaction.begin()
 
         assert_that(calling(TransactionLoop(handler)), raises(ForeignTransactionError))
+
+    def test_explicit_foreign_abort_fails(self):
+        def bad_abort():
+            raise Exception("Bad abort")
+
+        def handler():
+            transaction.abort()
+            tx = transaction.begin()
+            tx.abort = tx.nti_abort = bad_abort
+
+        assert_that(calling(TransactionLoop(handler)), raises(ForeignTransactionError))
+        assert_that(transaction.manager.manager, has_property('_txn', is_(none())))
 
     def test_setup_teardown(self):
 

--- a/src/nti/transactions/tests/test_transaction.py
+++ b/src/nti/transactions/tests/test_transaction.py
@@ -40,7 +40,7 @@ class TestCommit(unittest.TestCase):
         def __init__(self, t=Exception):
             self.t = t
 
-        def commit(self):
+        def nti_commit(self):
             if self.t:
                 raise self.t
 
@@ -186,7 +186,7 @@ class TestLoop(unittest.TestCase):
         fake_tx = fudge.Fake()
         (fake_tx
          .expects('note').with_args(u'Hi')
-         .expects('abort')
+         .expects('nti_abort')
          .provides('isDoomed').returns(True))
         fake_begin.expects_call().returns(fake_tx)
         fake_get.expects_call().returns(fake_tx)
@@ -202,7 +202,7 @@ class TestLoop(unittest.TestCase):
                  'transaction._manager.TransactionManager.get')
     def test_abort_no_side_effect(self, fake_begin, fake_get):
         fake_tx = fudge.Fake()
-        fake_tx.expects('abort')
+        fake_tx.expects('nti_abort')
 
         fake_begin.expects_call().returns(fake_tx)
         fake_get.expects_call().returns(fake_tx)
@@ -214,7 +214,7 @@ class TestLoop(unittest.TestCase):
         result = Loop(lambda: 42)()
         assert_that(result, is_(42))
 
-    @fudge.patch('transaction._transaction.Transaction.abort')
+    @fudge.patch('transaction._transaction.Transaction.nti_abort')
     def test_abort_doomed(self, fake_abort):
         fake_abort.expects_call()
 
@@ -230,7 +230,7 @@ class TestLoop(unittest.TestCase):
                  'transaction._manager.TransactionManager.get')
     def test_abort_veto(self, fake_begin, fake_get):
         fake_tx = fudge.Fake()
-        fake_tx.expects('abort')
+        fake_tx.expects('nti_abort')
         fake_tx.provides('isDoomed').returns(False)
 
         fake_begin.expects_call().returns(fake_tx)

--- a/src/nti/transactions/tests/test_transaction.py
+++ b/src/nti/transactions/tests/test_transaction.py
@@ -132,6 +132,25 @@ class TestLoop(unittest.TestCase):
 
         assert_that(calling(TransactionLoop(handler)), raises(ForeignTransactionError))
 
+    def test_setup_teardown(self):
+
+        class Loop(TransactionLoop):
+            setupcalled = teardowncalled = False
+            def setUp(self):
+                assert_that(transaction.manager, has_property('explicit', is_true()))
+                self.setupcalled = True
+            def tearDown(self):
+                self.teardowncalled = True
+
+        def handler():
+            raise Exception
+
+        loop = Loop(handler)
+        assert_that(calling(loop), raises(Exception))
+
+        assert_that(loop, has_property('setupcalled', is_true()))
+        assert_that(loop, has_property('teardowncalled', is_true()))
+
     def test_retriable(self, loop_class=TransactionLoop, exc_type=TransientError):
 
         calls = []

--- a/src/nti/transactions/transactions.py
+++ b/src/nti/transactions/transactions.py
@@ -557,6 +557,7 @@ class TransactionLoop(object):
             return self.__loop(txm, note, args, kwargs)
         finally:
             txm.explicit = was_explicit
+            self.tearDown()
 
     def __loop(self, txm, note, args, kwargs):
         number = self.attempts


### PR DESCRIPTION
Fixes #22

I see nti.site doing something like this in its subclass:
```python
class _RunJobInSite(TransactionLoop):

    def setUp(self):
        db = component.getUtility(IDatabase)
        self.conn = db.open()
        self.tearDown = self.conn.close
```

That means the object can't be used from multiple threads at the same time, but it's not used in that way anyway.


Also some minor refactoring with an eye towards speed and simplicity.

We get between 5 and 10% faster, even accounting for all the overhead of raising exceptions:

| Benchmark      | master |  this branch               |
|----------------|---------------|------------------------------|
| trivial commit | 14.9 us       | 13.2 us: 1.12x faster (-11%) |
| max retries    | 16.0 us       | 15.1 us: 1.06x faster (-5%)  |
