### PR TITLE
Pyramid tween reads configuration from registry.settings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.pyc
 *.sublime-*
 .coverage
+.coverage.*
 htmlcov/
 bin/
 develop-eggs/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@
   and in 5.0 they will be removed.
 
 - Add a Pyramid tween to manage transactions and transaction retries.
+  Various settings can be configured as Pyramid deployment settings
+  (e.g., in the ini file).
 
 - Make the transaction loop increase the time it sleeps between
   retries following the `random binary exponential backoff algorithm

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,8 @@ TESTS_REQUIRE = [
     'fudge',
     'nti.testing',
     'pylint',
+    'pyramid',
+    'zope.component',
     'zope.testrunner',
 ]
 
@@ -66,6 +68,9 @@ setup(
             'repoze.sphinx.autointerface',
             'pyhamcrest',
             'sphinx_rtd_theme',
+        ],
+        'pyramid': [
+            'pyramid >= 1.2',
         ],
     },
     entry_points=entry_points

--- a/src/nti/transactions/loop.py
+++ b/src/nti/transactions/loop.py
@@ -151,7 +151,7 @@ class TransactionLoop(object):
     AbortException = AbortAndReturn
 
     #: If not None, this is a number that specifies the base amount of time
-    #: to wait after a failed transaction attempt before retrying. Each
+    #: (in seconds) to wait after a failed transaction attempt before retrying. Each
     #: retry attempt will pick a delay following the binary exponential
     #: backoff algorithm: ``sleep * (random number between 0 and 2^retry-1)``.
     #: (A simple increasing multiplier might work well if there is only one other

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py27,py35,py36,py37,py38,pypy,pypy3,coverage
 [testenv]
 usedevelop = true
 commands =
-    zope-testrunner --test-path=src []
+    coverage run -p -m zope.testrunner --test-path=src
     pylint nti.transactions
 extras = test
 
@@ -13,7 +13,8 @@ extras = test
 basepython =
     python3.8
 commands =
-    coverage run -m zope.testrunner --test-path=src
+    coverage run -p -m zope.testrunner --test-path=src
+    coverage combine
     coverage report --fail-under=100
 deps =
     coverage


### PR DESCRIPTION
Fixes #29