### PR TITLE
Fix logging of long duration commits.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,8 @@
 3.1.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fix logging of long duration commits. See `issue 44
+  <https://github.com/NextThought/nti.transactions/issues/44>`_.
 
 
 3.1.0 (2019-11-29)

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ entry_points = {
 }
 
 TESTS_REQUIRE = [
+    'coverage',
     'fudge',
     'nti.testing',
     'pylint',

--- a/src/nti/transactions/pyramid_tween.py
+++ b/src/nti/transactions/pyramid_tween.py
@@ -151,10 +151,6 @@ class TransactionTween(TransactionLoop):
     and :func:`is_error_retryable` can be used to influence handler behaviour.
     """
 
-    # TODO: Take the number of attempts, sleep delay,
-    # delay backoff time/multiplier, long_commit_duration and
-    # side_effect_free as config params. Maybe model on pyramid_tm?
-
     def prep_for_retry(self, attempts_remaining, tx, request): # pylint:disable=arguments-differ
         """
         Prepares the request for possible retries.

--- a/src/nti/transactions/tests/test_loop.py
+++ b/src/nti/transactions/tests/test_loop.py
@@ -57,7 +57,7 @@ class TestCommit(unittest.TestCase):
 
         def nti_commit(self):
             if self.t:
-                raise self.t
+                raise self.t # (Python2, old pylint)  pylint:disable=raising-bad-type
 
     def RaisingCommit(self, t=Exception):
         return self.Transaction(t)


### PR DESCRIPTION
Fixes #44.

We were just passing the wrong arguments.