### PR TITLE
Require transaction 3.0 and drop dm.transaction.aborthook.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,10 +3,13 @@
  Changes
 =========
 
-3.1.2 (unreleased)
+4.0.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Require at least version 3.0 of the ``transaction`` package.
+
+- Drop dependency on the ``dm.transaction.aborthook`` package. That
+  functionality is now natively provided in transaction 3.0.
 
 
 3.1.1 (2019-12-10)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import codecs
 from setuptools import setup, find_packages
 
-version = '3.1.2.dev0'
+version = '4.0.0.dev0'
 
 entry_points = {
     'console_scripts': [
@@ -53,10 +53,9 @@ setup(
     namespace_packages=['nti'],
     tests_require=TESTS_REQUIRE,
     install_requires=[
-        'dm.transaction.aborthook',
         'perfmetrics',
         'setuptools',
-        'transaction >= 2.4.0',
+        'transaction >= 3.0.0',
         'zope.cachedescriptors',
         'zope.exceptions',
         'zope.interface',

--- a/src/nti/transactions/pyramid_tween.py
+++ b/src/nti/transactions/pyramid_tween.py
@@ -42,7 +42,7 @@ logger = __import__('logging').getLogger(__name__)
 from nti.transactions._httpexceptions import HTTPBadRequest
 from nti.transactions._httpexceptions import HTTPException
 from nti.transactions._loglevels import TRACE
-from nti.transactions.transactions import TransactionLoop
+from nti.transactions.loop import TransactionLoop
 
 __all__ = [
     'commit_veto',

--- a/src/nti/transactions/tests/test_loop.py
+++ b/src/nti/transactions/tests/test_loop.py
@@ -481,8 +481,8 @@ class TestLoop(unittest.TestCase):
             pass
 
     @fudge.patch('transaction._manager.TransactionManager.begin',
-                 'nti.transactions.transactions.logger.exception',
-                 'nti.transactions.transactions.logger.warning')
+                 'nti.transactions.loop.logger.exception',
+                 'nti.transactions.loop.logger.warning')
     def test_abort_exception_raises(self, fake_begin,
                                     fake_logger, fake_format):
         # begin() returns an object without abort(), which we catch.

--- a/src/nti/transactions/tests/test_transactions.py
+++ b/src/nti/transactions/tests/test_transactions.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the (deprecated) transactions.py.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import unittest
+import warnings
+
+# pylint:disable=bad-option-value,import-outside-toplevel
+
+class TestWarnings(unittest.TestCase):
+
+    def test_add_abort_hook(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+
+            import nti.transactions.transactions as T
+            T.add_abort_hooks()
+
+        self.assertEqual(len(w), 2, w)
+        self.assertIn('is deprecated', str(w[0]))
+        self.assertIn('test_transactions', str(w[0]))
+        self.assertIn('add_abort_hooks', str(w[1]))
+        self.assertIn('test_transactions', str(w[1]))

--- a/src/nti/transactions/transactions.py
+++ b/src/nti/transactions/transactions.py
@@ -12,13 +12,23 @@ logger = __import__('logging').getLogger(__name__)
 # BWC imports
 # For 4.0 makke this produce a deprecation warning. For 5.0
 # remove this.
-from dm.transaction.aborthook import add_abort_hooks
+import warnings
+
 from nti.transactions.loop import TransactionLoop
 from nti.transactions.manager import ObjectDataManager
 from nti.transactions.manager import OrderedNearEndObjectDataManager
 from nti.transactions.manager import do
 from nti.transactions.manager import do_near_end
 from nti.transactions.queue import put_nowait
+
+warnings.warn(
+    "nti.transactions.transactions is deprecated.",
+    FutureWarning,
+    stacklevel=2
+)
+
+def add_abort_hooks():
+    warnings.warn("add_abort_hooks is no longer needed.", FutureWarning, stacklevel=2)
 
 __all__ = [
     'ObjectDataManager',
@@ -27,5 +37,4 @@ __all__ = [
     'do',
     'do_near_end',
     'put_nowait',
-    'add_abort_hooks',
 ]


### PR DESCRIPTION
Make calling `add_abort_hooks` (kept for BWC) emit a warning.

Fixes #17