### PR TITLE
Various logging improvements.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,7 +8,6 @@ omit = src/nti/transactions/tests/*
 # specific
 exclude_lines =
     pragma: no cover
-    def __repr__
     raise AssertionError
     raise NotImplementedError
     if __name__ == .__main__.:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,10 +3,15 @@
  Changes
 =========
 
-4.0.2 (unreleased)
+4.2.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Add logging to the pyramid tween transaction factory to show the
+  settings that are in use.
+- Add ``TransactionLoop.side_effect_free_log_level``, and change the
+  default value to DEBUG. It is useful to set this to ERROR or higher
+  in tests.
+- Add ``TransactionLoop.side_effect_free_resource_limit``.
 
 
 4.0.1 (2020-07-18)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@
  Changes
 =========
 
-4.2.0 (unreleased)
+4.1.0 (unreleased)
 ==================
 
 - Add logging to the pyramid tween transaction factory to show the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -372,3 +372,5 @@ autodoc_default_options = {
     'members': True,
     'show-inheritance': True,
 }
+autodoc_member_order = 'groupwise'
+autodoc_content = 'both'

--- a/src/nti/transactions/pyramid_tween.py
+++ b/src/nti/transactions/pyramid_tween.py
@@ -29,8 +29,11 @@ Install this tween using the ``add_tween`` method::
         under=pyramid.tweens.EXCVIEW)
 
 You may install it under or over the exception view, depending on whether you
-need the transaction to be open
+need the transaction to be active in exception views.
 
+If you have a tween that manages a ZODB connection, it should be installed
+*above* this tween. That's because ZODB connections cannot be closed while
+joined to a transaction; the transaction must be committed or aborted first.
 """
 
 from __future__ import print_function
@@ -317,7 +320,9 @@ def transaction_tween_factory(handler, registry):
     long_commit_duration = setting('retry.long_commit_duration', float)
 
 
-    return TransactionTween(handler,
-                            retries=retries,
-                            sleep=sleep,
-                            long_commit_duration=long_commit_duration)
+    tween = TransactionTween(handler,
+                             retries=retries,
+                             sleep=sleep,
+                             long_commit_duration=long_commit_duration)
+    logger.info("Created tween %s", tween)
+    return tween


### PR DESCRIPTION
- Add a repr to the loop/tween.
- Log the tween when it is created.
- Add the ability to customize the log level for violations of the side-effect free policy and set it to DEBUG by default.
- Add the ability to raise an exception on side-effect free violations, based on the log level. Useful for testing.
- Limit the number of resources that will be reported for such violations; default is 5.