### PR TITLE
Log the exception message when aborting a transaction.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,13 @@
 4.2.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- When aborting a transaction due to an exception, log the exception
+  instead of just the exception type (twice). Exception messages can
+  be very helpful in understanding exactly what went wrong and
+  possibly how to fix it for transient errors (e.g., a
+  ``ZODB.POSException.ConflictError`` includes the object ID and
+  class, which can be used to reduce the conflicts). This makes the
+  logging slightly more expensive (when enabled).
 
 
 4.2.0 (2021-02-11)

--- a/setup.py
+++ b/setup.py
@@ -69,9 +69,9 @@ setup(
         'test': TESTS_REQUIRE,
         'gevent': ['gevent',],
         'docs': [
-            'Sphinx >= 2.1.2; python_version >= "3.0"',
-            # Sphinx 2+ does not support Python 2.7.
-            'Sphinx >= 1.8.5; python_version == "2.7"',
+            # Sphinx 4 and repoze.sphinx.autointerface 0.8
+            # are incompatible
+            'Sphinx < 4',
             'repoze.sphinx.autointerface',
             'pyhamcrest',
             'sphinx_rtd_theme',

--- a/src/nti/transactions/tests/test_manager.py
+++ b/src/nti/transactions/tests/test_manager.py
@@ -6,7 +6,7 @@ from __future__ import print_function, absolute_import, division
 import unittest
 
 from hamcrest import assert_that
-from hamcrest import contains
+from hamcrest import contains_exactly as contains
 from hamcrest import calling
 from hamcrest import raises
 from hamcrest import is_


### PR DESCRIPTION
This could contain extremely valuable data in the case of a ConflictError, for instance.